### PR TITLE
feat(kubevirt): VM stack (KubeVirt + CDI + Multus + kubevirt-manager)

### DIFF
--- a/clusters/personal/kubevirt/cdi-cr.yaml
+++ b/clusters/personal/kubevirt/cdi-cr.yaml
@@ -1,0 +1,16 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: CDI
+metadata:
+  name: cdi
+spec:
+  imagePullPolicy: IfNotPresent
+  config:
+    scratchSpaceStorageClass: single
+    featureGates:
+      - HonorWaitForFirstConsumer
+  infra:
+    nodeSelector:
+      kubernetes.io/os: linux
+  workload:
+    nodeSelector:
+      node-type: nvme

--- a/clusters/personal/kubevirt/cni-plugins-installer.yaml
+++ b/clusters/personal/kubevirt/cni-plugins-installer.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cni-plugins-installer
+  namespace: kube-system
+  labels:
+    app: cni-plugins-installer
+spec:
+  selector:
+    matchLabels:
+      app: cni-plugins-installer
+  template:
+    metadata:
+      labels:
+        app: cni-plugins-installer
+    spec:
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: install-cni-plugins
+          image: docker.io/curlimages/curl:8.20.0
+          # renovate: datasource=github-releases depName=containernetworking/plugins
+          env:
+            - name: CNI_PLUGINS_VERSION
+              value: v1.9.1
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              VERSION="${CNI_PLUGINS_VERSION}"
+              cd /host-cni-bin
+              curl -fsSL "https://github.com/containernetworking/plugins/releases/download/${VERSION}/cni-plugins-linux-amd64-${VERSION}.tgz" \
+                | tar -xz ./bridge ./tuning ./host-local ./static ./loopback ./portmap ./firewall ./vlan ./macvlan
+          volumeMounts:
+            - name: cni-bin
+              mountPath: /host-cni-bin
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 8Mi
+            limits:
+              cpu: 10m
+              memory: 16Mi
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate

--- a/clusters/personal/kubevirt/dns.yaml
+++ b/clusters/personal/kubevirt/dns.yaml
@@ -1,0 +1,15 @@
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: kubevirt-manager
+  namespace: kubevirt-manager
+spec:
+  endpoints:
+    - dnsName: kubevirt.cappyt.sh
+      recordTTL: 180
+      recordType: A
+      targets:
+        - 185.242.182.145
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/clusters/personal/kubevirt/external-secret.yaml
+++ b/clusters/personal/kubevirt/external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubevirt-manager-oidc
+  namespace: kubevirt-manager
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: kubevirt-manager-oidc
+    creationPolicy: Owner
+  data:
+    - secretKey: OAUTH2_PROXY_CLIENT_ID
+      remoteRef:
+        key: /kubevirt/oauth-client-id
+    - secretKey: OAUTH2_PROXY_CLIENT_SECRET
+      remoteRef:
+        key: /kubevirt/oauth-client-secret
+    - secretKey: OAUTH2_PROXY_COOKIE_SECRET
+      remoteRef:
+        key: /kubevirt/cookie-secret

--- a/clusters/personal/kubevirt/httproute.yaml
+++ b/clusters/personal/kubevirt/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kubevirt-manager
+  namespace: kubevirt-manager
+spec:
+  parentRefs:
+    - name: public-gateway
+      namespace: kube-system
+  hostnames:
+    - kubevirt.cappyt.sh
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: oauth2-proxy
+          port: 4180

--- a/clusters/personal/kubevirt/kubevirt-cr.yaml
+++ b/clusters/personal/kubevirt/kubevirt-cr.yaml
@@ -1,0 +1,30 @@
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  certificateRotateStrategy: {}
+  customizeComponents: {}
+  imagePullPolicy: IfNotPresent
+  workloadUpdateStrategy:
+    workloadUpdateMethods:
+      - LiveMigrate
+  configuration:
+    developerConfiguration:
+      featureGates:
+        - HotplugVolumes
+        - VMLiveUpdateFeatures
+    migrations:
+      completionTimeoutPerGiB: 800
+      progressTimeout: 150
+      parallelMigrationsPerCluster: 2
+      parallelOutboundMigrationsPerNode: 1
+  infra:
+    nodePlacement:
+      nodeSelector:
+        kubernetes.io/os: linux
+  workloads:
+    nodePlacement:
+      nodeSelector:
+        node-type: nvme

--- a/clusters/personal/kubevirt/kustomization.yaml
+++ b/clusters/personal/kubevirt/kustomization.yaml
@@ -1,0 +1,42 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # renovate: datasource=github-releases depName=kubevirt/kubevirt
+  - https://github.com/kubevirt/kubevirt/releases/download/v1.8.2/kubevirt-operator.yaml
+  - kubevirt-cr.yaml
+  # renovate: datasource=github-releases depName=kubevirt/containerized-data-importer
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.65.0/cdi-operator.yaml
+  - cdi-cr.yaml
+  # renovate: datasource=github-releases depName=k8snetworkplumbingwg/multus-cni
+  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.2.4/deployments/multus-daemonset-thick.yml
+  - cni-plugins-installer.yaml
+  - network-attachment-definition.yaml
+  - storageclass.yaml
+  # renovate: datasource=github-releases depName=kubevirt-manager/kubevirt-manager
+  - https://github.com/kubevirt-manager/kubevirt-manager/releases/download/v1.5.4/bundled-v1.5.4.yaml
+  - oauth2-proxy.yaml
+  - external-secret.yaml
+  - httproute.yaml
+  - dns.yaml
+patches:
+  - patch: |
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: kubevirt
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/warn: privileged
+  - patch: |
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: cdi
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/warn: privileged
+images:
+  - name: ghcr.io/k8snetworkplumbingwg/multus-cni
+    newTag: v4.2.4-thick

--- a/clusters/personal/kubevirt/network-attachment-definition.yaml
+++ b/clusters/personal/kubevirt/network-attachment-definition.yaml
@@ -1,0 +1,31 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: br0
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "br0",
+      "plugins": [
+        { "type": "bridge", "bridge": "br0", "ipam": {} },
+        { "type": "tuning" }
+      ]
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: br0
+  namespace: kubevirt
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "br0",
+      "plugins": [
+        { "type": "bridge", "bridge": "br0", "ipam": {} },
+        { "type": "tuning" }
+      ]
+    }

--- a/clusters/personal/kubevirt/oauth2-proxy.yaml
+++ b/clusters/personal/kubevirt/oauth2-proxy.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth2-proxy
+  namespace: kubevirt-manager
+  labels:
+    app: oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app: oauth2-proxy
+    spec:
+      containers:
+        - name: oauth2-proxy
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.2
+          args:
+            - --provider=oidc
+            - --oidc-issuer-url=https://auth.cappyt.sh/webman/sso
+            - --oidc-email-claim=sub
+            - --code-challenge-method=S256
+            - --scope=openid profile email
+            - --email-domain=*
+            - --upstream=http://kubevirt-manager.kubevirt-manager.svc.cluster.local:8080
+            - --http-address=0.0.0.0:4180
+            - --redirect-url=https://kubevirt.cappyt.sh/oauth2/callback
+            - --reverse-proxy=true
+            - --cookie-secure=true
+            - --skip-provider-button=true
+            - --set-xauthrequest=true
+          envFrom:
+            - secretRef:
+                name: kubevirt-manager-oidc
+          ports:
+            - name: http
+              containerPort: 4180
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oauth2-proxy
+  namespace: kubevirt-manager
+  labels:
+    app: oauth2-proxy
+spec:
+  type: ClusterIP
+  selector:
+    app: oauth2-proxy
+  ports:
+    - name: http
+      port: 4180
+      targetPort: 4180

--- a/clusters/personal/kubevirt/storageclass.yaml
+++ b/clusters/personal/kubevirt/storageclass.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: kubevirt-block
+provisioner: linstor.csi.linbit.com
+parameters:
+  linstor.csi.linbit.com/storagePool: nvme_pool
+  linstor.csi.linbit.com/placementCount: "3"
+  property.linstor.csi.linbit.com/DrbdOptions/Net/allow-two-primaries: "yes"
+  DrbdOptions/Disk/disk-flushes: "no"
+  DrbdOptions/Disk/md-flushes: "no"
+  DrbdOptions/Net/max-buffers: "10000"
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,19 @@
       "/clusters/.*/.*\\.yaml$/"
     ]
   },
+  "customManagers": [
+    {
+      "description": "Track versions pinned via '# renovate: datasource=... depName=...' comments (e.g. KubeVirt/CDI/Multus release-asset URLs)",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/clusters/.*\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+[\\s\\S]*?(?<currentValue>v?\\d+\\.\\d+\\.\\d+(?:-\\w+)?)"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
   "packageRules": [
     {
       "description": "Lock MySQL to v8",


### PR DESCRIPTION
Adds a VM platform on the cluster.

## What's in here
- **KubeVirt v1.8.2 + CDI v1.65.0** — operators via pinned GitHub release manifests, CRs with `LiveMigrate` workload updates and VM workloads pinned to the `node-type: nvme` workers (keeps VMs off the control-plane).
- **Multus v4.2.4 (thick)** + a `cni-plugins-installer` DaemonSet (Talos/Cilium don't ship the reference CNI plugins) + a `br0` `NetworkAttachmentDefinition`.
- **`kubevirt-block` StorageClass** — LINSTOR block-mode RWX, `placementCount 3`, `allow-two-primaries` → live migration without NFS/SMB. Normal VM disks keep using `single`/`replica`.
- **kubevirt-manager v1.5.4** behind a standalone **oauth2-proxy** (Synology SSO, PKCE) on `kubevirt.cappyt.sh` via the `public-gateway`.
- **renovate.json** `customManager` so the release-asset URLs / `CNI_PLUGINS_VERSION` get version bumps (they aren't behind a Flux source).

## Already done outside this PR
- Omni (cluster `Personal`): each "Hostname nodeiXX" patch got a `VLANConfig enp89s0.96` + `BridgeConfig br0`; `br0` is up on all workers.
- MikroTik: VLAN 96 `10.122.96.0/24` (`vm-net` iface, tagged on the `sfp-sfpplus1` trunk, pool `VM-NET`, DHCP server `VM`).

## Still TODO (manual)
- VLAN 96 on the downstream "SWITCH 2.5" trunk to the workers if it's VLAN-aware.
- Infisical keys `/kubevirt/oauth-client-id|oauth-client-secret|cookie-secret` + a DSM SSO client (redirect `https://kubevirt.cappyt.sh/oauth2/callback`).
- Smoke-test a VM (pod network first, then `br0`).