### PR TITLE
fix(cilium): vlanBPFBypass for VLAN 96 (KubeVirt VM bridge)

### DIFF
--- a/clusters/personal/kube-system/cilium.yaml
+++ b/clusters/personal/kube-system/cilium.yaml
@@ -31,6 +31,11 @@ spec:
   values:
     bpf:
       masquerade: true
+    # let VLAN 96 (the KubeVirt VM bridge `br0` lives on enp89s0.96) pass through the BPF
+    # datapath on the parent native device enp89s0 — Cilium doesn't manage that sub-interface
+    # (no IP) so without this it drops the traffic ("VLAN traffic disallowed by VLAN filter").
+    vlanBPFBypass:
+      - 96
     cgroup:
       autoMount:
         enabled: false


### PR DESCRIPTION
The KubeVirt VM bridge `br0` rides on `enp89s0.96`. Cilium attaches its BPF datapath to the parent native device `enp89s0` but doesn't manage `enp89s0.96` (it has no IP), so it was dropping VLAN-96 egress frames — `cilium_drop_count_total{direction=EGRESS,reason="VLAN traffic disallowed by VLAN filter"}` = 177 on nodei01. That's why VM DHCP on `10.122.96.0/24` never reached the MikroTik (the MG-108 switch is unmanaged/passive and was never the problem).

Adding VID 96 to `vlanBPFBypass` lets that traffic through the BPF on `enp89s0` untouched. Cilium agent rolls on reconcile (brief per-node datapath blip).