### PR TITLE
fix(cilium): correct value key bpf.vlanBypass for VLAN 96

### DIFF
--- a/clusters/personal/kube-system/cilium.yaml
+++ b/clusters/personal/kube-system/cilium.yaml
@@ -31,11 +31,11 @@ spec:
   values:
     bpf:
       masquerade: true
-    # let VLAN 96 (the KubeVirt VM bridge `br0` lives on enp89s0.96) pass through the BPF
-    # datapath on the parent native device enp89s0 — Cilium doesn't manage that sub-interface
-    # (no IP) so without this it drops the traffic ("VLAN traffic disallowed by VLAN filter").
-    vlanBPFBypass:
-      - 96
+      # let VLAN 96 (the KubeVirt VM bridge `br0` lives on enp89s0.96) pass through the BPF
+      # datapath on the parent native device enp89s0 — Cilium doesn't manage that sub-interface
+      # (no IP) so without this it drops the traffic ("VLAN traffic disallowed by VLAN filter").
+      vlanBypass:
+        - 96
     cgroup:
       autoMount:
         enabled: false


### PR DESCRIPTION
PR #503 put `vlanBPFBypass` at the values root, which the Cilium chart ignores — the right key is `bpf.vlanBypass`. So `vlan-bpf-bypass` in the ConfigMap stayed empty and VLAN-96 egress kept getting dropped (`cilium_drop_count_total{direction=EGRESS,reason="VLAN traffic disallowed by VLAN filter"}` still climbing). This moves it under `bpf:`. Verified: `helm template ... --set bpf.vlanBypass={96}` → ConfigMap `vlan-bpf-bypass: "96"`.

After merge: Cilium HelmRelease upgrades, agent rolls (brief per-node datapath blip), then VM DHCP on 10.122.96.0/24 should finally work.